### PR TITLE
[Security] Add backend sanitization for XSS protection

### DIFF
--- a/frontend_private/templates/pages/project/revision_history.html
+++ b/frontend_private/templates/pages/project/revision_history.html
@@ -264,11 +264,15 @@ $(window).on('load', function() {
                     $mobileItem.append($header);
                     
                     // Message
-                    $mobileItem.append('<div class="revision-message">' + commit.message + '</div>');
+                    var $msg = $('<div class="revision-message"></div>');
+                    $msg.text(commit.message);
+                    $mobileItem.append($msg);
                     
                     // Meta info
                     var $meta = $('<div class="revision-meta"></div>');
-                    $meta.append('<div class="revision-meta-item"><svg class="revision-meta-icon stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2"><path d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg><span>' + commit.author_name + '</span></div>');
+                    var $authorItem = $('<div class="revision-meta-item"><svg class="revision-meta-icon stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2"><path d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg><span></span></div>');
+                    $authorItem.find('span').text(commit.author_name);
+                    $meta.append($authorItem);
                     $meta.append('<div class="revision-meta-item"><svg class="revision-meta-icon stroke-current" fill="none" viewBox="0 0 24 24" stroke-width="2"><path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg><span>' + commit.authored_date + '</span></div>');
                     $mobileItem.append($meta);
                     

--- a/speleodb/gis/models/experiment.py
+++ b/speleodb/gis/models/experiment.py
@@ -29,6 +29,7 @@ from speleodb.gis.models import Station
 from speleodb.gis.models.utils import generate_random_token
 from speleodb.users.models import User
 from speleodb.utils.pydantic_utils import pydantic_to_django_validation_error
+from speleodb.utils.sanitize import sanitize_text
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -123,11 +124,22 @@ class ExperimentFieldDefinition(PydanticBaseModel):
 
     @field_validator("name", mode="before")
     @classmethod
-    def titlecase_name(cls, v: str) -> str:
-        """Convert name to titlecase."""
+    def sanitize_and_titlecase_name(cls, v: str) -> str:
+        """Sanitize then titlecase the field name."""
         if isinstance(v, str):
-            return v.title()
+            return sanitize_text(v).title()
         return v
+
+    @field_validator("options", mode="before")
+    @classmethod
+    def sanitize_options(cls, v: list[str] | None) -> list[str] | None:
+        """Sanitize each option string and reject empty results."""
+        if v is None:
+            return v
+        sanitized = [sanitize_text(opt) if isinstance(opt, str) else opt for opt in v]
+        if any(opt == "" for opt in sanitized):
+            raise ValueError("Option values must not be empty after sanitization")
+        return sanitized
 
     @model_validator(mode="after")
     def validate_field(self) -> ExperimentFieldDefinition:

--- a/speleodb/gis/tests/test_experiment_model.py
+++ b/speleodb/gis/tests/test_experiment_model.py
@@ -1124,7 +1124,7 @@ class TestExperimentFieldSanitization:
 
     def test_html_mixed_with_text_stripped(self) -> None:
         field_def = ExperimentFieldDefinition(
-            name='<b>Temperature</b> <script>alert(1)</script>',
+            name="<b>Temperature</b> <script>alert(1)</script>",
             type=FieldType.TEXT,
             required=False,
             order=0,
@@ -1149,7 +1149,7 @@ class TestExperimentFieldSanitization:
             required=False,
             order=0,
             options=[
-                '<b>Bold</b> Option',
+                "<b>Bold</b> Option",
                 "Normal Option",
             ],
         )

--- a/speleodb/gis/tests/test_experiment_model.py
+++ b/speleodb/gis/tests/test_experiment_model.py
@@ -6,6 +6,7 @@ import re
 
 import pytest
 from django.core.exceptions import ValidationError
+from pydantic import ValidationError as PydanticValidationError
 
 from speleodb.gis.models import Experiment
 from speleodb.gis.models.experiment import ExperimentFieldDefinition
@@ -1106,3 +1107,78 @@ class TestExperimentModel:
             "Field B",
             "Field A",
         ]
+
+
+class TestExperimentFieldSanitization:
+    """Test that ExperimentFieldDefinition sanitizes name and options."""
+
+    def test_pure_html_field_name_rejected(self) -> None:
+        """A name that is only HTML tags gets stripped to empty and fails min_length."""
+        with pytest.raises(PydanticValidationError):
+            ExperimentFieldDefinition(
+                name='<img src=x onerror="alert(1)">',
+                type=FieldType.TEXT,
+                required=False,
+                order=0,
+            )
+
+    def test_html_mixed_with_text_stripped(self) -> None:
+        field_def = ExperimentFieldDefinition(
+            name='<b>Temperature</b> <script>alert(1)</script>',
+            type=FieldType.TEXT,
+            required=False,
+            order=0,
+        )
+        assert "<" not in field_def.name
+        assert "Temperature" in field_def.name
+
+    def test_zalgo_stripped_from_field_name(self) -> None:
+        zalgo = "Z\u0300\u0301\u0302\u0303\u0304\u0305a\u0300\u0301l\u0300g\u0300o"
+        field_def = ExperimentFieldDefinition(
+            name=zalgo,
+            type=FieldType.TEXT,
+            required=False,
+            order=0,
+        )
+        assert field_def.name == "Zalgo"
+
+    def test_html_stripped_from_select_options(self) -> None:
+        field_def = ExperimentFieldDefinition(
+            name="Pick One",
+            type=FieldType.SELECT,
+            required=False,
+            order=0,
+            options=[
+                '<b>Bold</b> Option',
+                "Normal Option",
+            ],
+        )
+        assert field_def.options is not None
+        for opt in field_def.options:
+            assert "<" not in opt
+            assert ">" not in opt
+        assert "Bold Option" in field_def.options
+        assert "Normal Option" in field_def.options
+
+    def test_pure_html_option_rejected(self) -> None:
+        """An option that is only HTML tags sanitizes to empty and is rejected."""
+        with pytest.raises(PydanticValidationError):
+            ExperimentFieldDefinition(
+                name="Pick One",
+                type=FieldType.SELECT,
+                required=False,
+                order=0,
+                options=[
+                    '<script>alert("xss")</script>',
+                    "Normal Option",
+                ],
+            )
+
+    def test_normal_name_preserved(self) -> None:
+        field_def = ExperimentFieldDefinition(
+            name="Temperature (C)",
+            type=FieldType.NUMBER,
+            required=True,
+            order=0,
+        )
+        assert field_def.name == "Temperature (C)"

--- a/speleodb/surveys/models/mutex.py
+++ b/speleodb/surveys/models/mutex.py
@@ -7,6 +7,7 @@ from django.db.models import indexes
 
 from speleodb.surveys.models import Project
 from speleodb.users.models import User
+from speleodb.utils.sanitize import sanitize_text
 
 
 class ProjectMutex(models.Model):
@@ -60,5 +61,5 @@ class ProjectMutex(models.Model):
     def release_mutex(self, user: User, comment: str) -> None:
         self.is_active = False
         self.closing_user = user.email
-        self.closing_comment = comment
+        self.closing_comment = sanitize_text(comment)
         self.save()

--- a/speleodb/surveys/models/project_commit.py
+++ b/speleodb/surveys/models/project_commit.py
@@ -11,6 +11,7 @@ from django.db import models
 from django.utils import timezone
 
 from speleodb.surveys.models import Project
+from speleodb.utils.sanitize import sanitize_text
 
 if TYPE_CHECKING:
     from speleodb.git_engine.core import GitCommit
@@ -110,20 +111,22 @@ class ProjectCommit(models.Model):
         with contextlib.suppress(cls.DoesNotExist):
             return ProjectCommit.objects.get(id=commit.hexsha)
 
+        raw_message = (
+            message
+            if isinstance(message := commit.message, str)
+            else message.decode("utf-8", errors="ignore")
+        )
+
         return ProjectCommit.objects.create(
             id=commit.hexsha,
             project=project,
-            author_name=commit.author.name or "",
+            author_name=sanitize_text(commit.author.name or ""),
             author_email=commit.author.email or "",
             authored_date=datetime.fromtimestamp(
                 commit.authored_date,
                 tz=timezone.get_current_timezone(),
             ),
-            message=(
-                message
-                if isinstance(message := commit.message, str)
-                else message.decode("utf-8", errors="ignore")
-            ),
+            message=sanitize_text(raw_message),
             parent_ids=[parent.hexsha for parent in commit.parents],
             tree=commit.tree_to_json(),
         )

--- a/speleodb/surveys/tests/test_project_commit.py
+++ b/speleodb/surveys/tests/test_project_commit.py
@@ -275,3 +275,119 @@ class TestProjectCommitModel(TestCase):
         )
 
         assert commit.tree == {}
+
+
+class TestGetOrCreateFromCommitSanitization(TestCase):
+    """Test that get_or_create_from_commit sanitizes text fields."""
+
+    def setUp(self) -> None:
+        self.user = UserFactory.create()
+        self.project = ProjectFactory.create(created_by=self.user.email)
+
+    @staticmethod
+    def _make_fake_commit(
+        hexsha: str,
+        message: str,
+        author_name: str = "Test Author",
+        author_email: str = "test@example.com",
+    ) -> object:
+        """Build a minimal mock matching the GitCommit interface."""
+
+        class _Author:
+            def __init__(self, name: str, email: str) -> None:
+                self.name = name
+                self.email = email
+
+        class _FakeCommit:
+            def __init__(
+                self,
+                hexsha: str,
+                message: str,
+                author: _Author,
+                authored_date: float,
+            ) -> None:
+                self.hexsha = hexsha
+                self.message = message
+                self.author = author
+                self.authored_date = authored_date
+                self.parents: list[object] = []
+
+            def tree_to_json(self) -> list[dict[str, str]]:
+                return []
+
+        return _FakeCommit(
+            hexsha=hexsha,
+            message=message,
+            author=_Author(author_name, author_email),
+            authored_date=timezone.now().timestamp(),
+        )
+
+    def test_html_stripped_from_message(self) -> None:
+        fake = self._make_fake_commit(
+            hexsha="a" * 40,
+            message='<script>alert("xss")</script> normal text',
+        )
+        commit = ProjectCommit.get_or_create_from_commit(self.project, fake)  # type: ignore[arg-type]
+        assert "<script>" not in commit.message
+        assert "normal text" in commit.message
+
+    def test_html_stripped_from_author_name(self) -> None:
+        fake = self._make_fake_commit(
+            hexsha="b" * 40,
+            message="clean message",
+            author_name='<img src=x onerror="alert(1)">',
+        )
+        commit = ProjectCommit.get_or_create_from_commit(self.project, fake)  # type: ignore[arg-type]
+        assert "<img" not in commit.author_name
+
+    def test_zalgo_stripped_from_message(self) -> None:
+        zalgo = "Z\u0300\u0301\u0302\u0303\u0304\u0305\u0306\u0307a\u0300\u0301\u0302\u0303l\u0300\u0301g\u0300o"
+        fake = self._make_fake_commit(
+            hexsha="c" * 40,
+            message=f"{zalgo} commit",
+        )
+        commit = ProjectCommit.get_or_create_from_commit(self.project, fake)  # type: ignore[arg-type]
+        assert "Zalgo commit" in commit.message
+
+    def test_existing_commit_returned_unchanged(self) -> None:
+        """get_or_create should return existing commit without re-sanitizing."""
+        ProjectCommitFactory.create(
+            id="d" * 40,
+            project=self.project,
+            message="original message",
+        )
+        fake = self._make_fake_commit(
+            hexsha="d" * 40,
+            message="different message",
+        )
+        commit = ProjectCommit.get_or_create_from_commit(self.project, fake)  # type: ignore[arg-type]
+        assert commit.message == "original message"
+
+
+class TestMutexClosingCommentSanitization(TestCase):
+    """Test that ProjectMutex.release_mutex sanitizes the closing comment."""
+
+    def setUp(self) -> None:
+        from speleodb.surveys.models.mutex import ProjectMutex
+
+        self.user = UserFactory.create()
+        self.project = ProjectFactory.create(created_by=self.user.email)
+        self.mutex = ProjectMutex.objects.create(
+            project=self.project, user=self.user, is_active=True
+        )
+
+    def test_html_stripped_from_closing_comment(self) -> None:
+        from speleodb.surveys.models.mutex import ProjectMutex
+
+        self.mutex.release_mutex(self.user, '<script>alert("xss")</script> done')
+        self.mutex.refresh_from_db()
+        assert "<script>" not in self.mutex.closing_comment
+        assert "done" in self.mutex.closing_comment
+
+    def test_zalgo_stripped_from_closing_comment(self) -> None:
+        from speleodb.surveys.models.mutex import ProjectMutex
+
+        zalgo = "Z\u0300\u0301\u0302\u0303a\u0300\u0301l\u0300g\u0300o"
+        self.mutex.release_mutex(self.user, f"{zalgo} release")
+        self.mutex.refresh_from_db()
+        assert "Zalgo release" in self.mutex.closing_comment

--- a/speleodb/surveys/tests/test_project_commit.py
+++ b/speleodb/surveys/tests/test_project_commit.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from speleodb.api.v1.tests.factories import ProjectCommitFactory
 from speleodb.api.v1.tests.factories import ProjectFactory
 from speleodb.surveys.models import ProjectCommit
+from speleodb.surveys.models.mutex import ProjectMutex
 from speleodb.users.tests.factories import UserFactory
 
 
@@ -341,7 +342,10 @@ class TestGetOrCreateFromCommitSanitization(TestCase):
         assert "<img" not in commit.author_name
 
     def test_zalgo_stripped_from_message(self) -> None:
-        zalgo = "Z\u0300\u0301\u0302\u0303\u0304\u0305\u0306\u0307a\u0300\u0301\u0302\u0303l\u0300\u0301g\u0300o"
+        zalgo = (
+            "Z\u0300\u0301\u0302\u0303\u0304\u0305\u0306\u0307"
+            "a\u0300\u0301\u0302\u0303l\u0300\u0301g\u0300o"
+        )
         fake = self._make_fake_commit(
             hexsha="c" * 40,
             message=f"{zalgo} commit",
@@ -368,8 +372,6 @@ class TestMutexClosingCommentSanitization(TestCase):
     """Test that ProjectMutex.release_mutex sanitizes the closing comment."""
 
     def setUp(self) -> None:
-        from speleodb.surveys.models.mutex import ProjectMutex
-
         self.user = UserFactory.create()
         self.project = ProjectFactory.create(created_by=self.user.email)
         self.mutex = ProjectMutex.objects.create(
@@ -377,16 +379,12 @@ class TestMutexClosingCommentSanitization(TestCase):
         )
 
     def test_html_stripped_from_closing_comment(self) -> None:
-        from speleodb.surveys.models.mutex import ProjectMutex
-
         self.mutex.release_mutex(self.user, '<script>alert("xss")</script> done')
         self.mutex.refresh_from_db()
         assert "<script>" not in self.mutex.closing_comment
         assert "done" in self.mutex.closing_comment
 
     def test_zalgo_stripped_from_closing_comment(self) -> None:
-        from speleodb.surveys.models.mutex import ProjectMutex
-
         zalgo = "Z\u0300\u0301\u0302\u0303a\u0300\u0301l\u0300g\u0300o"
         self.mutex.release_mutex(self.user, f"{zalgo} release")
         self.mutex.refresh_from_db()

--- a/speleodb/utils/sanitize.py
+++ b/speleodb/utils/sanitize.py
@@ -8,10 +8,10 @@ import unicodedata
 
 import nh3
 
+# Legitimate scripts (Thai, Vietnamese, IPA) use up to 3 combining marks
+# per base character.  Zalgo text stacks 10-50+.  Marks beyond this limit
+# are silently dropped.
 MAX_COMBINING_MARKS_PER_CHAR = 3
-"""Legitimate scripts (Thai, Vietnamese, IPA) use up to 3 combining marks
-per base character.  Zalgo text stacks 10-50+.  Marks beyond this limit
-are silently dropped."""
 
 
 def sanitize_text(value: str) -> str:

--- a/speleodb/utils/sanitize.py
+++ b/speleodb/utils/sanitize.py
@@ -8,6 +8,11 @@ import unicodedata
 
 import nh3
 
+MAX_COMBINING_MARKS_PER_CHAR = 3
+"""Legitimate scripts (Thai, Vietnamese, IPA) use up to 3 combining marks
+per base character.  Zalgo text stacks 10-50+.  Marks beyond this limit
+are silently dropped."""
+
 
 def sanitize_text(value: str) -> str:
     """
@@ -21,21 +26,20 @@ def sanitize_text(value: str) -> str:
         3. NFD (canonical) decomposition — splits precomposed characters into
            base + combining marks (e.g. ``é`` → ``e`` + combining-acute)
            without touching compatibility characters (``™``, ``№`` stay).
-        4. Strip **all** combining marks (Unicode "Mark" categories Mn/Mc/Me).
+        4. Cap combining marks at ``MAX_COMBINING_MARKS_PER_CHAR`` per base
+           character — preserves legitimate accents (``é``, ``ñ``) while
+           blocking Zalgo text that stacks 10-50+ marks per character.
         5. NFC recomposition — recombine any remaining valid sequences.
         6. Remove control / format characters (Cc/Cf) except whitespace.
         7. Collapse runs of whitespace and strip edges.
-
-    .. note::
-
-        Accented characters (``é`` → ``e``, ``ñ`` → ``n``) are also
-        stripped.  This trade-off keeps the logic simple and safe.
 
     Example:
         >>> sanitize_text("D̸̨̛͖̯̘̦͔̱̱͖͔̻͖͜ͅa̵̧̡̢̳͓̝̟̩̬̪̻̝̠̻̩̜̫̤...")
         'DaniS'
         >>> sanitize_text('<b>bold</b>')
         'bold'
+        >>> sanitize_text('Température')
+        'Température'
     """
     if not value:
         return value
@@ -47,23 +51,36 @@ def sanitize_text(value: str) -> str:
     #    We store plain text, not HTML, so entities must be decoded.
     value = html.unescape(value)
 
-    # 2. NFD decomposition — splits precomposed chars into base + marks.
-    #    Unlike NFKD, does NOT expand compatibility chars (™, №, ﬁ stay).
+    # 3. NFD decomposition — splits precomposed chars into base + marks.
     value = unicodedata.normalize("NFD", value)
 
-    # 2. Strip ALL combining marks.
-    value = "".join(ch for ch in value if unicodedata.category(ch)[0] != "M")
+    # 4. Cap combining marks per base character (blocks Zalgo, keeps accents).
+    #    Marks before any base character are dropped entirely.
+    result: list[str] = []
+    has_base = False
+    mark_count = 0
+    for ch in value:
+        if unicodedata.category(ch)[0] == "M":
+            if has_base:
+                mark_count += 1
+                if mark_count <= MAX_COMBINING_MARKS_PER_CHAR:
+                    result.append(ch)
+        else:
+            has_base = True
+            mark_count = 0
+            result.append(ch)
+    value = "".join(result)
 
-    # 3. NFC recomposition.
+    # 5. NFC recomposition.
     value = unicodedata.normalize("NFC", value)
 
-    # 4. Remove control / format characters except normal whitespace.
+    # 6. Remove control / format characters except normal whitespace.
     value = "".join(
         ch
         for ch in value
         if unicodedata.category(ch) not in {"Cc", "Cf"} or ch in "\n\r\t "
     )
 
-    # 5. Normalise whitespace: collapse runs and strip.
+    # 7. Normalise whitespace: collapse runs and strip.
     value = re.sub(r"[ \t]+", " ", value)
     return value.strip()

--- a/speleodb/utils/tests/test_sanitize.py
+++ b/speleodb/utils/tests/test_sanitize.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import unicodedata
+
 from speleodb.utils.sanitize import sanitize_text
 
 
@@ -12,8 +14,8 @@ class TestSanitizeText:
     # Zalgo / combining-mark abuse
     # ------------------------------------------------------------------
 
-    def test_zalgo_text_stripped_to_base_characters(self) -> None:
-        """Heavily decorated zalgo text should collapse to plain letters."""
+    def test_zalgo_text_reduced_to_near_base_characters(self) -> None:
+        """Heavily decorated zalgo text should have excess marks stripped."""
         zalgo = (
             "D\u0338\u0328\u031b\u0356\u032f\u0318\u0326\u0354\u0331\u0331\u0356"
             "\u0354\u033b\u0356\u035c\u0345a\u0335\u0327\u0321\u0322\u0333\u0353"
@@ -33,16 +35,24 @@ class TestSanitizeText:
             "\u033f\u0308\u0302\u0301\u0315\u030a\u030d\u0308\u0302\u030a\u0301"
             "\u033d\u0303\u0300\u0345"
         )
-        assert sanitize_text(zalgo) == "DaniS"
+        result = sanitize_text(zalgo)
+        # Base characters survive; excess marks are stripped
+        base_only = "".join(
+            c for c in result if unicodedata.category(c)[0] != "M"
+        )
+        assert base_only == "DaniS"
+        # Each base char keeps at most 3 combining marks
+        mark_count = len(result) - len(base_only)
+        assert mark_count <= len(base_only) * 3
 
-    def test_simple_combining_accent_removed(self) -> None:
-        """A single combining acute accent on 'e' should be stripped."""
-        # 'e' + combining acute accent (U+0301)
-        assert sanitize_text("e\u0301") == "e"
+    def test_simple_combining_accent_preserved(self) -> None:
+        """A single combining acute accent on 'e' should be kept."""
+        # 'e' + combining acute accent (U+0301) → recomposed to 'é'
+        assert sanitize_text("e\u0301") == "é"
 
-    def test_precomposed_accent_decomposed_and_stripped(self) -> None:
-        """Pre-composed é is decomposed by NFD and the accent removed."""
-        assert sanitize_text("\u00e9") == "e"
+    def test_precomposed_accent_preserved(self) -> None:
+        """Pre-composed é should survive sanitization."""
+        assert sanitize_text("\u00e9") == "é"
 
     # ------------------------------------------------------------------
     # Compatibility characters preserved (NFD, not NFKD)
@@ -68,23 +78,22 @@ class TestSanitizeText:
         assert sanitize_text("Станция №1") == "Станция №1"
 
     # ------------------------------------------------------------------
-    # Accented characters are stripped to base letters
+    # Accented characters are preserved (up to 3 marks per base char)
     # ------------------------------------------------------------------
 
-    def test_accented_latin_stripped(self) -> None:
-        """Common accented Latin letters lose their diacritics."""
-        assert sanitize_text("café") == "cafe"
-        assert sanitize_text("naïve") == "naive"
-        assert sanitize_text("résumé") == "resume"
+    def test_accented_latin_preserved(self) -> None:
+        """Common accented Latin letters keep their diacritics."""
+        assert sanitize_text("café") == "café"
+        assert sanitize_text("naïve") == "naïve"
+        assert sanitize_text("résumé") == "résumé"
 
-    def test_n_tilde_stripped(self) -> None:
-        """ñ is decomposed and the tilde removed."""
-        assert sanitize_text("niño") == "nino"
+    def test_n_tilde_preserved(self) -> None:
+        """ñ should survive sanitization."""
+        assert sanitize_text("niño") == "niño"
 
-    def test_devanagari_marks_stripped(self) -> None:
-        """Devanagari combining marks (virama, vowel signs) are stripped."""
-        # स्टेशन → सटशन (virama and vowel sign removed)
-        assert sanitize_text("स्टेशन") == "सटशन"
+    def test_devanagari_marks_preserved(self) -> None:
+        """Devanagari combining marks within the limit are preserved."""
+        assert sanitize_text("स्टेशन") == "स्टेशन"
 
     # ------------------------------------------------------------------
     # Control / format characters

--- a/speleodb/utils/tests/test_sanitize.py
+++ b/speleodb/utils/tests/test_sanitize.py
@@ -37,9 +37,7 @@ class TestSanitizeText:
         )
         result = sanitize_text(zalgo)
         # Base characters survive; excess marks are stripped
-        base_only = "".join(
-            c for c in result if unicodedata.category(c)[0] != "M"
-        )
+        base_only = "".join(c for c in result if unicodedata.category(c)[0] != "M")
         assert base_only == "DaniS"
         # Each base char keeps at most 3 combining marks
         mark_count = len(result) - len(base_only)


### PR DESCRIPTION
Follow-up with a few more fixes. Since the input-time sanitization has been included, I am adding it in a few more important places.

Namely:
-  Experiment field name + options
- Git commit message + author name (covers both git and UI upload)
- Mutex closing comment
- Revision history page injection in mobile view

This applies all existing sanitization (so should the xss sanitizaiton be removed in the future from input-time, it still covers zelgo etc).

Issue illustration on staging under my acc:
1. My Survey Project -> Revision History, Lock Management
2. GIS experiments -> Sanitization Test Experiment -> Fields/Options zelgo + <> pass through
3. same -> Data Viewer -> Station name passes unsanitized
4. Survey map -> Survey Stations -> Click any -> Experiment Data -> select SANTEST -> columns have <>/zelgo